### PR TITLE
Update Travis dotnet to 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 2.0.0
+dotnet: 2.2
 script:
   - dotnet restore
   - dotnet build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: csharp
 mono: none
+dist: xenial
 dotnet: 2.2
 script:
   - dotnet restore


### PR DESCRIPTION
In order to support new builds (especially the license keyword), update travis to dotnet 2.2.
Closes #21 